### PR TITLE
require mocha_standalone instead of mocha to avoid failure

### DIFF
--- a/lib/mocha-on-bacon.rb
+++ b/lib/mocha-on-bacon.rb
@@ -1,4 +1,4 @@
-require "mocha"
+require "mocha_standalone"
 
 module Bacon
   module MochaRequirementsCounter


### PR DESCRIPTION
mocha >= 0.12.0 fails explicitly if mocha is required as discussed
in freerange/mocha#88. Suggestion is to require new file.

I've verified that mocha_standalone exists for the current minimum mocha allowed in the gemspec - 0.9.8.
